### PR TITLE
向cookies获取脚本添加www.miyoushe.com的支持

### DIFF
--- a/docs/help/xunkong/account.md
+++ b/docs/help/xunkong/account.md
@@ -16,7 +16,7 @@
 
 > 需要的是访问 `https://bbs.mihoyo.com/ys/` 页面时发送的 Cookie（复制 Header 中的内容即可）
 
-- 把右侧的文字拖入浏览器书签栏 <a href="javascript:(()=>{if(location.host.includes('bbs.mihoyo.com')){var cookie=document.cookie;navigator.clipboard.writeText(cookie);alert('Cookie 已复制到剪贴板')}else{alert('当前网页不为米游社页面')}})();">获取米游社 Cookie</a>
+- 把右侧的文字拖入浏览器书签栏 <a href="javascript:(()=>{if(location.host.includes('www.miyoushe.com') || location.host.includes('bbs.mihoyo.com')){var cookie=document.cookie;navigator.clipboard.writeText(cookie);alert('Cookie 已复制到剪贴板')}else{alert('当前网页不为米游社页面')}})();">获取米游社 Cookie</a>
 - 使用浏览器的**无痕模式**打开 [米游社·原神](https://bbs.mihoyo.com/ys/)页面
 - 登录您需要添加到寻空中的账号
 - 点击之前添加的书签，此时 Cookie 已被复制到剪贴板
@@ -46,7 +46,7 @@
 
 ``` js
 javascript: (() => {
-    if (location.host.includes('bbs.mihoyo.com')) {
+    if (location.host.includes('www.miyoushe.com') || location.host.includes('bbs.mihoyo.com')) {
         var cookie = document.cookie;
         navigator.clipboard.writeText(cookie);
         alert('Cookie 已复制到剪贴板');


### PR DESCRIPTION
也就是说，现在支持www.miyoushe.com和bbs.mihoyo.com的脚本爬取了。
所用脚本在Edge 108.0.1462.42 64位正式版/Windows 11 x64 21H2测试通过

doc中的位置在这：https://xunkong.cc/help/xunkong/account.html#%E9%80%9A%E8%BF%87-cookie-%E6%B7%BB%E5%8A%A0%E8%B4%A6%E5%8F%B7